### PR TITLE
Build to common x86_64_v3 architecture

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update && apt-get install -y \
     libc6-dev \
     python3
 
-RUN git clone -c feature.manyFiles=true https://github.com/spack/spack.git
+RUN git clone -c feature.manyFiles=true --depth=2 https://github.com/spack/spack.git
 
 ENV PATH="${PATH}:/spack/bin"
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # Spack Distroless
 A minimal container environment to test Spack builds.
 
+```
+podman run --rm -it ghcr.io/spack/spack-distroless
+```
+
 ## License
 
 This project is part of Spack. Spack is distributed under the terms of both the

--- a/spack.yaml
+++ b/spack.yaml
@@ -30,5 +30,8 @@ spack:
     python:
       root: /python-view
       select: [python]
+  packages:
+    all:
+      target: [x86_64_v3]
   concretizer:
     unify: true


### PR DESCRIPTION
When building the bootstrap environment we should build to the `x86_64_v3` arch to maximize reusability later.