### PR TITLE
Drop configuring compilers as externals

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,8 +55,6 @@ COPY --from=base /usr/bin/env /usr/bin/env
 ENV SPACK_PYTHON=/python-view/bin/python3
 ENV PATH=/view/bin:/spack/bin:/bin
 
-RUN spack compiler find
-
 RUN spack bootstrap now
 
 ENTRYPOINT ["/bin/sh"]

--- a/spack.yaml
+++ b/spack.yaml
@@ -19,16 +19,17 @@ spack:
   view:
     final:
       root: /view
+      link: run
       select:
         - binutils
         - coreutils
-        - gcc
         - git
         - patch
         - tar
         - unzip
     python:
       root: /python-view
+      link: run
       select: [python]
   packages:
     all:


### PR DESCRIPTION
Attempting to the fix the following errors during concretization.

```
# spack spec go
==> Error: failed to concretize `go` for the following reasons:
     1. Only external, or concrete, compilers are allowed for the cxx language
     2. Only external, or concrete, compilers are allowed for the c language
```